### PR TITLE
Only use shared keysets on supported platforms

### DIFF
--- a/Source/CJSONDeserializer.m
+++ b/Source/CJSONDeserializer.m
@@ -62,12 +62,13 @@ typedef struct
     {
     if ((self = [super init]) != NULL)
         {
+        _data = nil;
         _nullObject = [NSNull null];
         _options = kJSONDeserializationOptions_Default;
 
         CFDictionaryKeyCallBacks theCallbacks = {};
         _stringsByHash = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &theCallbacks, &kCFTypeDictionaryValueCallBacks);
-        _useSharedKeys = (NSFoundationVersionNumber >= NSFoundationVersionNumber10_8);
+        _useSharedKeys = (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_6_0);
         }
     return (self);
     }
@@ -158,7 +159,7 @@ typedef struct
 
 - (BOOL)_setData:(NSData *)inData error:(NSError **)outError;
     {
-    if (_data == inData)
+    if (_data == inData || inData.length < 1)
         {
         if (outError)
             {

--- a/Source/CJSONDeserializer.m
+++ b/Source/CJSONDeserializer.m
@@ -45,6 +45,7 @@ typedef struct
     char *_start;
     NSMutableData *_scratchData;
     CFMutableDictionaryRef _stringsByHash;
+    BOOL _useSharedKeys;
     }
 @end
 
@@ -66,6 +67,7 @@ typedef struct
 
         CFDictionaryKeyCallBacks theCallbacks = {};
         _stringsByHash = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &theCallbacks, &kCFTypeDictionaryValueCallBacks);
+        _useSharedKeys = (NSFoundationVersionNumber >= NSFoundationVersionNumber10_8);
         }
     return (self);
     }
@@ -498,7 +500,7 @@ typedef struct
             }
         }
 
-    if (ioSharedKeySet != NULL && *ioSharedKeySet == NULL)
+    if (_useSharedKeys && ioSharedKeySet != NULL && *ioSharedKeySet == NULL)
         {
         *ioSharedKeySet = [NSMutableDictionary sharedKeySetForKeys:[theDictionary allKeys]];
         }


### PR DESCRIPTION
-[NSMutableDictionary sharedKeySetForKeys:] and
-[NSMutableDictionary dictionaryWithSharedKeySet:] were added in 10.8 &
6.0.  This patch tests foundation version at -init and disables the use
of this feature on older OS versions.

Patch for poor bastards still running on iOS 5.
